### PR TITLE
adding browserify transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ You can also grab the full template [data object](https://github.com/bigpipe/tem
 var data = tempistry.serialize('/my/templates/file.jade', true);
 ```
 
+## Browserify Transform
+
+If you're using Browserify, the easiest way to plug tempistry into your pipeline is via the included transform, `tempistry/transform`.  You can then require your template files directly and have them automatically registered with tempistry.
+
+
+```bash
+# Via cli
+browserify -t tempistry/transform main.js
+```
+
+```javascript
+// Via api
+var b = browserify().transform('tempistry/transform');
+```
+
+
+```javascript
+// register pre-render hook
+var tempistry = require('tempistry');
+
+tempistry.on('pre-render', function(data) {
+	data.helpers = myViewHelpers;
+});
+
+var template = require('./things.jade');
+
+// *helpers* will be available in the template due to the pre-render hook above
+var html = template({
+	name: 'Kellan'
+});
+```
+
 ## Client-Side
 
 Tempistry runs in the browser w/ browserify and acts as a registry to hook pre/post render logic into.  This is useful for mixing in common view data such as formatting helpers.  It works well when combined with the server side `serialize()` function, but you can register any function you want with it.
@@ -44,16 +76,18 @@ Tempistry runs in the browser w/ browserify and acts as a registry to hook pre/p
 var tempistry = require('tempistry');
 
 // register functions w/ the global tempistry lib, receive the template function back
-var template = tempistry.register(function() { /** function string provider from server-side tempistry.serialize() call*/});
+var template = tempistry.register(function() { /** function string provided from server-side tempistry.serialize() call*/});
 
 // mixin pre/post render logic
 tempistry.on('pre-render', function(data) {
+    // override "name"
     data.name = 'asher';
 });
 
-// wire in post-render logic, receiving the data that was rendered
-tempistry.on('post-render', function(data) {
-    console.log(data.name); // ahser
+// wire in post-render logic, receiving the data that was rendered and the html string
+tempistry.on('post-render', function(result) {
+    console.log(result.data.name); // asher
+    console.log(result.html); // html string returned from template fn
 });
 
 // call the template function
@@ -63,6 +97,7 @@ var html = template({
 
 // name will be 'asher' in the html produced
 ```
+
 
 ## License
 This software is free to use under the Yahoo! Inc. BSD license.

--- a/index.js
+++ b/index.js
@@ -20,3 +20,10 @@ exports.serializeSource = function(source, filename, returnData) {
 
     return !!returnData ? data : data.client;
 };
+
+// Return an array of supported file extensions
+exports.extensions = function() {
+    return Object.keys(temper.supported).map(function(ext) {
+        return ext.replace(/^\./, '');
+    });
+};

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "temper": "~0.1.8",
-    "deap": "~0.2.2"
+    "deap": "^1.0.0",
+    "through": "^2.3.6"
   }
 }

--- a/test/fixtures/not-a-template.js
+++ b/test/fixtures/not-a-template.js
@@ -1,0 +1,1 @@
+module.exports = 'notatemplate';

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -10,6 +10,8 @@ describe('tempistry', function() {
 
     it('should be defined correctly', function() {
         assert.isFunction(tempistry.serialize);
+        assert.isFunction(tempistry.serializeSource);
+        assert.isFunction(tempistry.extensions);
     });
 
     it('tempistry.serialize defaults', function () {
@@ -54,6 +56,15 @@ describe('tempistry', function() {
         assert.isFunction(template.server);
         assert.match(template.client, (/<h1>bai/));
         assert.equal(template.server({name:'Kellan'}), '<h1>bai Kellan</h1>');
+
+    });
+
+    it('tempistry.extensions should return an array of file extensions', function() {
+        var extensions = tempistry.extensions();
+
+        assert.isArray(extensions);
+        assert.isTrue(extensions.length > 0);
+        extensions.forEach(assert.isString.bind(assert));
 
     });
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,0 +1,70 @@
+var assert = require('chai').assert,
+    fs = require('fs'),
+    path = require('path'),
+    transform = require('../transform');
+
+describe('tempistry transform', function() {
+    var ROOT = path.join(__dirname, 'fixtures'),
+        templateFile = path.join(ROOT, 'bai.jade'),
+        transformRegex = /^module\.exports = require\(\"tempistry\"\)\.register/;
+
+    it('should be a function', function() {
+        assert.isFunction(transform);
+    });
+
+    it('should return a duplex stream', function() {
+        var stream = transform(path.join(ROOT, 'bai.jade'));
+
+        assert.isObject(stream);
+        assert.isTrue(stream.writable);
+        assert.isTrue(stream.readable);
+        assert.isFunction(stream.write);
+        assert.isFunction(stream.push);
+        assert.isFunction(stream.queue);
+        assert.isFunction(stream.end);
+        assert.isFunction(stream.destroy);
+        assert.isFunction(stream.pause);
+        assert.isFunction(stream.resume);
+    });
+
+    it('should transform a jade file', function(done) {
+        var asserted = false,
+            stream = transform(templateFile);
+
+        stream
+            .on('data', function(src) {
+                assert.match(src, transformRegex);
+                asserted = true;
+            })
+            .on('end', function() {
+                assert.isTrue(asserted);
+                done();
+            });
+
+        fs.createReadStream(templateFile, { encoding: 'utf8' })
+            .pipe(stream);
+    });
+
+    it('should not transform a non-template file', function(done){
+        var asserted = false,
+            notTemplateFile = path.join(ROOT, 'not-a-template.js'),
+            notTemplateSource = require(notTemplateFile),
+            notTemplateRegex = /^module\.exports = 'notatemplate';/,
+            stream = transform(notTemplateFile);
+
+        stream
+            .on('data', function(src) {
+                assert.notMatch(src, transformRegex);
+                assert.match(src, notTemplateRegex);
+                asserted = true;
+            })
+            .on('end', function() {
+                assert.isTrue(asserted);
+                done();
+            });
+
+        fs.createReadStream(notTemplateFile, { encoding: 'utf8' })
+            .pipe(stream);
+    });
+
+});

--- a/transform.js
+++ b/transform.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+var through = require('through'),
+    tempistry = require('./index'),
+    EXT_TEST = new RegExp('\\.('+tempistry.extensions().join('|')+')$');
+
+// stream that transforms template files into compiled templates registered w/ tempistry
+module.exports = function transformer(file, options) {
+    if (!EXT_TEST.test(file)) {
+        return through();
+    }
+
+    var buffer = '',
+        stream = through(
+            function(str) {
+                buffer += str;
+            },
+            function() {
+                this.queue(transform(buffer, file, options));
+                this.queue(null);
+            }
+        );
+
+    return stream;
+};
+
+// returns js string with compiled template registered w/ tempistry
+function transform(str, file, options) {
+    return [
+        'module.exports = require("tempistry").register(', tempistry.serializeSource(str, file), ');'
+    ].join('');
+}


### PR DESCRIPTION
Most common use case for `tempistry` is with a browserify transform, so adding it here.
